### PR TITLE
Port TradingView strategy to MT5 EA

### DIFF
--- a/MQL5/Experts/PropEA/MasterEA.mq5
+++ b/MQL5/Experts/PropEA/MasterEA.mq5
@@ -1,0 +1,191 @@
+//+------------------------------------------------------------------+
+//|                                                    MasterEA.mq5 |
+//|       Ported from TradingView strategy                          |
+//|                                                                  |
+//|  This EA executes trades on a prop account and writes hedge      |
+//|  instructions for a second terminal.                             |
+//+------------------------------------------------------------------+
+#property copyright ""
+#property version   "1.00"
+#property strict
+
+#include <Trade/Trade.mqh>
+#include <Files/File.mqh>
+#include <Dashboard.mqh>
+
+CTrade      trade;
+
+//--- input parameters
+input double   RiskPercent    = 0.3;   // risk per trade in percent
+input double   FixedLot       = 1.0;   // fixed lot size when RiskPercent=0
+input bool     UseRiskPercent = true;  // use risk percent or fixed lot
+input double   HedgeFactor    = 1.0;   // hedge lot multiplier
+input string   SignalFile     = "hedge_signal.txt"; // file for hedge instructions
+
+// scale-out and breakeven settings
+input bool     EnableScaleOut = true;    // enable partial profit taking
+input double   ScaleOutPct    = 50;      // percent of distance to TP for scale-out
+input double   ScaleOutSize   = 50;      // percent of position to close
+input bool     ScaleOutBE     = true;    // set breakeven after scale-out
+input bool     EnableBreakEven = false;  // enable breakeven without scale-out
+input double   BreakEvenTrigger = 100;   // profit in points to trigger breakeven
+
+
+
+//--- global variables
+bool hasPosition=false;
+double lastLots=0.0;
+double lastSL=0.0;
+double lastTP=0.0;
+bool  scaleOutDone=false;
+bool  breakEvenDone=false;
+
+//+------------------------------------------------------------------+
+//| Expert initialization function                                   |
+//+------------------------------------------------------------------+
+int OnInit()
+  {
+   DashboardInit();
+   return(INIT_SUCCEEDED);
+  }
+
+//+------------------------------------------------------------------+
+//| Expert deinitialization function                                 |
+//+------------------------------------------------------------------+
+void OnDeinit(const int reason)
+  {
+   DashboardShutdown();
+  }
+
+//+------------------------------------------------------------------+
+//| Calculate lots based on risk settings                             |
+//+------------------------------------------------------------------+
+double CalcLots(double sl_points)
+  {
+   if(!UseRiskPercent || sl_points<=0)
+      return(FixedLot);
+
+   double risk_money=AccountInfoDouble(ACCOUNT_BALANCE)*RiskPercent/100.0;
+   double lotstep=SymbolInfoDouble(_Symbol,SYMBOL_VOLUME_STEP);
+   double tick_value=SymbolInfoDouble(_Symbol,SYMBOL_TRADE_TICK_VALUE);
+   double tick_size=SymbolInfoDouble(_Symbol,SYMBOL_TRADE_TICK_SIZE);
+   double value_per_point=tick_value/tick_size;
+   double lots=risk_money/(sl_points*value_per_point);
+   lots=MathMax(lotstep,MathFloor(lots/lotstep)*lotstep);
+   return(NormalizeDouble(lots,2));
+  }
+
+//+------------------------------------------------------------------+
+//| Send hedge instruction to file                                    |
+//+------------------------------------------------------------------+
+void SendHedgeSignal(string direction,double lots,double sl,double tp)
+  {
+   int file=FileOpen(SignalFile,FILE_WRITE|FILE_TXT|FILE_COMMON);
+   if(file!=INVALID_HANDLE)
+     {
+      string line=StringFormat("%s,%s,%f,%f,%f",TimeToString(TimeCurrent(),TIME_DATE|TIME_SECONDS),direction,lots,sl,tp);
+      FileWriteString(file,line+"\n");
+      FileClose(file);
+     }
+  }
+
+//+------------------------------------------------------------------+
+//| Expert tick function                                              |
+//+------------------------------------------------------------------+
+void OnTick()
+  {
+   //--- update dashboard
+   DashboardOnTick();
+
+   //--- check if we have an open position
+   hasPosition=(PositionSelect(_Symbol));
+
+   //--- compute signals
+   double fast=iMA(_Symbol,_Period,50,0,MODE_EMA,PRICE_CLOSE,0);
+   double slow=iMA(_Symbol,_Period,200,0,MODE_EMA,PRICE_CLOSE,0);
+   bool longCondition=(fast>slow);
+   bool shortCondition=(fast<slow);
+
+   if(!hasPosition)
+     {
+      //--- open position if condition met
+      double sl,tp;
+      if(longCondition)
+        {
+         sl=SymbolInfoDouble(_Symbol,SYMBOL_BID)-100*_Point;
+         tp=SymbolInfoDouble(_Symbol,SYMBOL_BID)+200*_Point;
+         double lots=CalcLots(100);
+         if(trade.Buy(lots,_Symbol,0,sl,tp))
+           {
+            lastLots=lots; lastSL=sl; lastTP=tp;
+            scaleOutDone=false;
+            breakEvenDone=false;
+            SendHedgeSignal("SELL",lots*HedgeFactor,sl,tp);
+         }
+      }
+      else if(shortCondition)
+        {
+         sl=SymbolInfoDouble(_Symbol,SYMBOL_ASK)+100*_Point;
+         tp=SymbolInfoDouble(_Symbol,SYMBOL_ASK)-200*_Point;
+         double lots=CalcLots(100);
+         if(trade.Sell(lots,_Symbol,0,sl,tp))
+           {
+            lastLots=lots; lastSL=sl; lastTP=tp;
+            scaleOutDone=false;
+            breakEvenDone=false;
+            SendHedgeSignal("BUY",lots*HedgeFactor,sl,tp);
+           }
+        }
+     }
+   else
+     {
+     ulong ticket=PositionGetTicket(0);
+     int type=PositionGetInteger(POSITION_TYPE);
+     double entry=PositionGetDouble(POSITION_PRICE_OPEN);
+     double volume=PositionGetDouble(POSITION_VOLUME);
+     double bid=SymbolInfoDouble(_Symbol,SYMBOL_BID);
+     double ask=SymbolInfoDouble(_Symbol,SYMBOL_ASK);
+     double profit_in_points=(type==POSITION_TYPE_BUY)? (bid-entry)/_Point : (entry-ask)/_Point;
+
+     //--- scale-out logic
+     if(EnableScaleOut && !scaleOutDone)
+       {
+        double scalePrice=entry;
+        if(type==POSITION_TYPE_BUY)
+           scalePrice=entry + (lastTP-entry)*ScaleOutPct/100.0;
+        else
+           scalePrice=entry - (entry-lastTP)*ScaleOutPct/100.0;
+
+        if((type==POSITION_TYPE_BUY && bid>=scalePrice) ||
+           (type==POSITION_TYPE_SELL && ask<=scalePrice))
+          {
+           double closeLots=NormalizeDouble(volume*(ScaleOutSize/100.0),2);
+           if(closeLots>0.0 && trade.PositionClosePartial(ticket,closeLots))
+             {
+              scaleOutDone=true;
+              lastLots-=closeLots;
+              SendHedgeSignal("SO",closeLots,0,0);
+
+              if(ScaleOutBE && !breakEvenDone)
+                {
+                 trade.PositionModify(ticket,entry,lastTP);
+                 lastSL=entry;
+                 breakEvenDone=true;
+                }
+             }
+          }
+       }
+
+     //--- breakeven logic
+     if(EnableBreakEven && !breakEvenDone && profit_in_points>=BreakEvenTrigger)
+       {
+        if(trade.PositionModify(ticket,entry,lastTP))
+          {
+           lastSL=entry;
+           breakEvenDone=true;
+          }
+       }
+     }
+  }
+
+//+------------------------------------------------------------------+

--- a/MQL5/Experts/PropEA/SlaveEA.mq5
+++ b/MQL5/Experts/PropEA/SlaveEA.mq5
@@ -1,0 +1,74 @@
+//+------------------------------------------------------------------+
+//|                                                     SlaveEA.mq5  |
+//|  Opens opposite trades based on instructions from MasterEA       |
+//+------------------------------------------------------------------+
+#property copyright ""
+#property version   "1.00"
+#property strict
+
+#include <Trade/Trade.mqh>
+#include <Files/File.mqh>
+#include <Dashboard.mqh>
+
+CTrade trade;
+
+input string SignalFile = "hedge_signal.txt";  // shared signal file
+
+// last time processed
+datetime lastSignalTime=0;
+
+int OnInit()
+  {
+   DashboardInit();
+   return(INIT_SUCCEEDED);
+  }
+
+void OnDeinit(const int reason)
+  {
+   DashboardShutdown();
+  }
+
+// parse a line from the signal file
+bool ParseSignal(string line,string &direction,double &lots,double &sl,double &tp)
+  {
+   string parts[];
+   int count=StringSplit(line,',',parts);
+   if(count<5) return(false);
+   datetime t=StringToTime(parts[0]);
+   if(t<=lastSignalTime) return(false);
+   lastSignalTime=t;
+   direction=parts[1];
+   lots=StringToDouble(parts[2]);
+   sl=StringToDouble(parts[3]);
+   tp=StringToDouble(parts[4]);
+   return(true);
+  }
+
+void CheckSignals()
+  {
+   int file=FileOpen(SignalFile,FILE_READ|FILE_TXT|FILE_COMMON);
+   if(file==INVALID_HANDLE) return;
+   while(!FileIsEnding(file))
+     {
+      string line=FileReadString(file);
+      if(line=="" || StringFind(line,"ADJ")>=0) continue; // ignore adjustments
+      string dir; double lots,sl,tp;
+      if(ParseSignal(line,dir,lots,sl,tp))
+        {
+         if(dir=="BUY" && !PositionSelect(_Symbol))
+            trade.Buy(lots,_Symbol,0,sl,tp);
+         else if(dir=="SELL" && !PositionSelect(_Symbol))
+            trade.Sell(lots,_Symbol,0,sl,tp);
+         else if(dir=="SO" && PositionSelect(_Symbol))
+            trade.PositionClosePartial(PositionGetTicket(0),lots);
+        }
+     }
+   FileClose(file);
+  }
+
+void OnTick()
+  {
+   DashboardOnTick();
+   CheckSignals();
+  }
+//+------------------------------------------------------------------+

--- a/MQL5/Include/Dashboard.mqh
+++ b/MQL5/Include/Dashboard.mqh
@@ -1,0 +1,48 @@
+//+------------------------------------------------------------------+
+//| Dashboard include                                                |
+//+------------------------------------------------------------------+
+
+class CDashboard
+  {
+private:
+   long   chart_id;
+   int    y;
+public:
+   void Init()
+     {
+      chart_id=ChartID();
+      y=20;
+      ObjectCreate(chart_id,"dash_bg",OBJ_LABEL,0,0,0);
+      ObjectSetInteger(chart_id,"dash_bg",OBJPROP_CORNER,0);
+      ObjectSetInteger(chart_id,"dash_bg",OBJPROP_XDISTANCE,10);
+      ObjectSetInteger(chart_id,"dash_bg",OBJPROP_YDISTANCE,10);
+      ObjectSetString(chart_id,"dash_bg",OBJPROP_TEXT,"MarketCrasher Dashboard");
+      ObjectSetInteger(chart_id,"dash_bg",OBJPROP_FONTSIZE,12);
+     }
+   void Update()
+     {
+      // additional stats can be drawn here
+     }
+   void Shutdown()
+     {
+      ObjectDelete(chart_id,"dash_bg");
+     }
+  };
+
+static CDashboard dashboard;
+
+void DashboardInit()
+  {
+   dashboard.Init();
+  }
+
+void DashboardOnTick()
+  {
+   dashboard.Update();
+  }
+
+void DashboardShutdown()
+  {
+   dashboard.Shutdown();
+  }
+//+------------------------------------------------------------------+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# MarketCrasher EA
+
+This repository contains the MetaTrader 5 implementation of the TradingView strategy described in `TradingView PropStrategy .txt`.
+
+Two EAs are provided:
+
+- **MasterEA** – trades the prop account and writes hedge instructions for the slave.
+- **SlaveEA** – reads hedge instructions from file and opens opposite trades on a hedge account.
+
+A dashboard implementation is available in `MQL5/Include/Dashboard.mqh`.
+
+The Master EA now includes optional **scale-out** logic allowing partial profit
+taking and breakeven management.
+
+## Usage
+1. Place the files inside your terminal's `MQL5` directory preserving the folder structure.
+2. Compile `MQL5/Experts/PropEA/MasterEA.mq5` and `MQL5/Experts/PropEA/SlaveEA.mq5` in MetaEditor.
+3. Attach `MasterEA` to the prop account chart and `SlaveEA` to the hedge account chart.
+
+Adjust the input parameters of both EAs to match your desired risk and strategy settings.


### PR DESCRIPTION
## Summary
- add MasterEA and SlaveEA skeletons for MetaTrader 5
- implement a minimal dashboard include
- provide basic usage instructions in README
- add scale-out and breakeven logic

## Testing
- `git status --short`
