### PR TITLE
Add default path for compile script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,4 +12,8 @@ You are granted access to run any actions and workflows set in this repository.
 
 You are granted access to create Pull Request as soon as you complete the task, access Pull Requests on github, resolve conflicts (if any), merge and commit.
 
-IMPORTANT ----> Code that you deliver must be error/warning-free. 
+IMPORTANT ----> Code that you deliver must be error/warning-free.
+
+## Tasks
+
+- Compile the EAs using `scripts/compile.sh`. Provide the MetaTrader installation path via the `METATRADER_PATH` environment variable or as a command-line argument. If omitted, the script assumes `/Applications`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ Synergy score logic from the TradingView script is implemented in
 
 ## Usage
 1. Place the files inside your terminal's `MQL5` directory preserving the folder structure.
-2. Compile `MQL5/Experts/PropEA/MasterEA.mq5` and `MQL5/Experts/PropEA/SlaveEA.mq5` in MetaEditor.
+2. Compile `MQL5/Experts/PropEA/MasterEA.mq5` and `MQL5/Experts/PropEA/SlaveEA.mq5` in MetaEditor or run the helper script:
+
+   ```sh
+   METATRADER_PATH=/path/to/MetaTrader5 ./scripts/compile.sh
+
+   # or pass the path as an argument
+   ./scripts/compile.sh /path/to/MetaTrader5
+  ```
+   The path should point to the folder containing `metaeditor64.exe` from your MetaTrader 5 installation. If no path is provided, the script defaults to `/Applications` which is the typical location on macOS.
 3. Attach `MasterEA` to the prop account chart and `SlaveEA` to the hedge account chart.
 
 Adjust the input parameters of both EAs to match your desired risk and strategy settings.

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+cd "$SCRIPT_DIR/.."
+
+MT5_PATH="${1:-${METATRADER_PATH:-/Applications}}"
+
+if [ -z "$MT5_PATH" ]; then
+  echo "Usage: METATRADER_PATH=/path/to/MetaTrader ./scripts/compile.sh" >&2
+  echo "   or: ./scripts/compile.sh /path/to/MetaTrader" >&2
+  exit 1
+fi
+
+EXE="$MT5_PATH/metaeditor64.exe"
+if [ ! -f "$EXE" ]; then
+  echo "metaeditor64.exe not found in $MT5_PATH" >&2
+  exit 1
+fi
+
+"$EXE" /compile:"MQL5/Experts/PropEA/MasterEA.mq5" /log:"MasterEA.log"
+"$EXE" /compile:"MQL5/Experts/PropEA/SlaveEA.mq5" /log:"SlaveEA.log"
+


### PR DESCRIPTION
## Summary
- default compile.sh to `/Applications`
- explain the default path in README
- document compile script usage in AGENTS.md

## Testing
- `./scripts/compile.sh` *(fails: metaeditor64.exe not found in /Applications)*
- `./scripts/compile.sh /tmp` *(fails: metaeditor64.exe not found in /tmp)*
